### PR TITLE
fix(theme): prevent inputDecorationTheme override + architecture refactor

### DIFF
--- a/.github/workflows/pin_code.yaml
+++ b/.github/workflows/pin_code.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
 
-          flutter-version: '3.38.0'
+          flutter-version: '3.38.5'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/pin_code.yaml
+++ b/.github/workflows/pin_code.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
 
-          flutter-version: '3.32.2'
+          flutter-version: '3.38.0'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/pin_code.yaml
+++ b/.github/workflows/pin_code.yaml
@@ -12,7 +12,7 @@ jobs:
 
   build_and_test:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+### 1.2.0
+
+#### Fixed
+- **Theme InputDecoration Override**: Fixed an issue where the app's `inputDecorationTheme` was overriding the hidden `TextFormField` styles, causing it to become visible behind the PIN fields. Added explicit transparent decorations (`fillColor`, `focusColor`, `hoverColor`, `errorBorder`, `focusedErrorBorder`, `disabledBorder`) to prevent theme inheritance. (Thanks to [@Pavluke](https://github.com/Pavluke) for reporting and suggesting the fix in [PR #2](https://github.com/JhonaCodes/pin_code/pull/2))
+
+#### Added
+- **`inputDecoration` Parameter**: Exposed optional `InputDecoration` parameter in `PinCode` widget, allowing users to customize the hidden input field decoration if needed.
+
+#### Changed
+- **Architecture Refactor**: Improved code structure following Flutter coding standards:
+  - **`PinFieldStyleCalculator`**: New class that separates style calculation logic from UI rendering.
+  - **`PinFieldData` Record**: Dart 3 record type containing pre-calculated styles (fillColor, border) for each field.
+  - **`_PinField` Widget**: Extracted individual PIN field rendering into a dedicated `StatelessWidget`.
+  - **Functional Composition**: Replaced imperative `_generateFields()` loop with `.expand().toList()` pattern for cleaner widget generation.
+- **Private Widgets**: Converted all internal builder methods to private `StatelessWidget` classes (`_HiddenTextFormField`, `_PinFieldsRow`, `_PinField`, `_PinFieldChild`).
+
+### 1.1.0
+- **Dart 3 Modernization**: Applied enum shorthand syntax across the entire project (`.center` instead of `Alignment.center`).
+- **New `_PinFieldChild` Widget**: Extracted PIN field content logic into a dedicated private `StatelessWidget` for better separation of concerns.
+- **Switch Expressions**: Replaced if-else chains with Dart 3 switch expressions and pattern matching for cleaner, more declarative code.
+- **Code Simplification**: Reduced boilerplate with arrow functions and collection-if syntax.
+
 ### 1.0.2
 -  **Update Readme**.
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -14,7 +14,7 @@ class PasscodeScreen extends StatelessWidget {
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 32.0),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: .center,
           children: [
             const Icon(
               Icons.lock_outline_rounded,
@@ -27,7 +27,7 @@ class PasscodeScreen extends StatelessWidget {
               style: TextStyle(
                 color: Colors.white,
                 fontSize: 22,
-                fontWeight: FontWeight.bold,
+                fontWeight: .bold,
               ),
             ),
             const SizedBox(height: 48),
@@ -42,7 +42,7 @@ class PasscodeScreen extends StatelessWidget {
                   log("🔑 Passcode entered: $value");
                 },
                 pinTheme: PinCodeTheme(
-                  shape: PinCodeFieldShape.box,
+                  shape: .box,
                   borderRadius: BorderRadius.circular(10),
                   fieldHeight: 60,
                   fieldWidth: 60,

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -88,11 +88,11 @@ class PinCodeTheme {
     this.inactiveBorderWidth = 1.0,
     this.disabledBorderWidth = 1.0,
     this.errorBorderWidth = 1.0,
-    this.borderRadius = BorderRadius.zero,
+    this.borderRadius = .zero,
     this.fieldHeight = 50.0,
     this.fieldWidth = 40.0,
-    this.shape = PinCodeFieldShape.underline,
-    this.fieldOuterPadding = EdgeInsets.zero,
+    this.shape = .underline,
+    this.fieldOuterPadding = .zero,
   });
 
   /// Creates a copy of this theme but with the given fields replaced with the new values.
@@ -140,3 +140,83 @@ class PinCodeTheme {
 }
 
 //endregion
+
+
+
+/// Pre-calculated style data for a single PIN field.
+///
+/// Contains the computed visual properties (colors, borders) based on
+/// the current state of the field (active, selected, disabled, error).
+typedef PinFieldData = ({
+  int index,
+  String character,
+  Color fillColor,
+  Border? border,
+});
+
+/// Calculates visual styles for PIN fields based on their state.
+///
+/// Separates style computation logic from UI rendering, allowing
+/// the widget to use a functional approach with `.map()` and `.expand()`.
+class PinFieldStyleCalculator {
+  const PinFieldStyleCalculator({
+    required this.pinTheme,
+    required this.enabled,
+    required this.hasFocus,
+    required this.selectedIndex,
+    required this.isInErrorMode,
+    required this.enableActiveFill,
+  });
+
+  final PinCodeTheme pinTheme;
+  final bool enabled;
+  final bool hasFocus;
+  final int selectedIndex;
+  final bool isInErrorMode;
+  final bool enableActiveFill;
+
+  /// Generates style data for all PIN fields.
+  ///
+  /// Returns a list of [PinFieldData] records containing pre-calculated
+  /// fill colors and borders for each field index.
+  List<PinFieldData> calculate(int length, List<String> inputList) =>
+      List.generate(length, (i) => (
+      index: i,
+      character: inputList[i],
+      fillColor: enableActiveFill ? _getFillColor(i) : Colors.transparent,
+      border: _getBorder(i),
+      ));
+
+  Color _getFillColor(int index) {
+    if (!enabled) return pinTheme.disabledColor;
+    if (hasFocus && selectedIndex == index) return pinTheme.selectedFillColor;
+    if (selectedIndex > index) return pinTheme.activeFillColor;
+    return pinTheme.inactiveFillColor;
+  }
+
+  Border? _getBorder(int index) {
+    final color = _getBorderColor(index);
+    final width = _getBorderWidth(index);
+
+    if (pinTheme.shape == PinCodeFieldShape.underline) {
+      return Border(bottom: BorderSide(color: color, width: width));
+    }
+    return Border.all(color: color, width: width);
+  }
+
+  Color _getBorderColor(int index) {
+    if (isInErrorMode) return pinTheme.errorBorderColor;
+    if (!enabled) return pinTheme.disabledColor;
+    if (hasFocus && selectedIndex == index) return pinTheme.selectedColor;
+    if (selectedIndex > index) return pinTheme.activeColor;
+    return pinTheme.inactiveColor;
+  }
+
+  double _getBorderWidth(int index) {
+    if (isInErrorMode) return pinTheme.errorBorderWidth;
+    if (!enabled) return pinTheme.disabledBorderWidth;
+    if (hasFocus && selectedIndex == index) return pinTheme.selectedBorderWidth;
+    if (selectedIndex > index) return pinTheme.activeBorderWidth;
+    return pinTheme.inactiveBorderWidth;
+  }
+}

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -67,10 +67,10 @@ mixin PinCodeMixin on State<PinCode> {
       vsync: this as TickerProvider,
     );
 
-    offsetAnimation =
-        Tween<Offset>(begin: Offset.zero, end: const Offset(0.1, 0.0)).animate(
-          CurvedAnimation(parent: errorController, curve: Curves.elasticIn),
-        );
+    offsetAnimation = Tween<Offset>(
+      begin: Offset.zero,
+      end: const Offset(0.1, 0.0),
+    ).animate(CurvedAnimation(parent: errorController, curve: Curves.elasticIn));
 
     cursorAnimation = Tween<double>(
       begin: 1,
@@ -82,21 +82,19 @@ mixin PinCodeMixin on State<PinCode> {
     }
 
     errorController.addStatusListener((status) {
-      if (status == AnimationStatus.completed) {
+      if (status == .completed) {
         errorController.reverse();
       }
     });
 
-    errorAnimationSubscription = widget.errorAnimationController?.stream.listen(
-      (error) {
-        if (error == PinCodeErrorAnimationType.shake) {
-          errorController.forward();
-          setState(() => isInErrorMode = true);
-        } else if (error == PinCodeErrorAnimationType.clear) {
-          setState(() => isInErrorMode = false);
-        }
-      },
-    );
+    errorAnimationSubscription = widget.errorAnimationController?.stream.listen((error) {
+      if (error == .shake) {
+        errorController.forward();
+        setState(() => isInErrorMode = true);
+      } else if (error == .clear) {
+        setState(() => isInErrorMode = false);
+      }
+    });
   }
 
   /// Disposes all resources used by the widget.
@@ -127,10 +125,7 @@ mixin PinCodeMixin on State<PinCode> {
           if (currentText.length > widget.length) {
             currentText = currentText.substring(0, widget.length);
           }
-          Future.delayed(
-            const Duration(milliseconds: 100),
-            () => widget.onCompleted!(currentText),
-          );
+          Future.delayed(const Duration(milliseconds: 100), () => widget.onCompleted!(currentText));
         }
         if (widget.autoDismissKeyboard) {
           focusNode!.unfocus();
@@ -147,10 +142,7 @@ mixin PinCodeMixin on State<PinCode> {
         focusNode!.hasFocus &&
         MediaQuery.of(context).viewInsets.bottom == 0) {
       focusNode!.unfocus();
-      Future.delayed(
-        const Duration(microseconds: 1),
-        () => focusNode!.requestFocus(),
-      );
+      Future.delayed(const Duration(microseconds: 1), () => focusNode!.requestFocus());
     } else {
       focusNode!.requestFocus();
     }
@@ -182,241 +174,444 @@ mixin PinCodeMixin on State<PinCode> {
             : pinTheme.fieldHeight + widget.errorTextSpace,
         color: widget.backgroundColor,
         child: Stack(
-          alignment: Alignment.bottomCenter,
-          children: <Widget>[_buildHiddenTextFormField(), _buildPinFields()],
-        ),
-      ),
-    );
-  }
-
-  /// Builds the hidden [TextFormField] that actually handles the text input.
-  Widget _buildHiddenTextFormField() {
-    return AbsorbPointer(
-      absorbing: true,
-      child: AutofillGroup(
-        onDisposeAction: widget.onAutoFillDisposeAction,
-        child: TextFormField(
-          controller: textEditingController,
-          focusNode: focusNode,
-          enabled: widget.enabled,
-          autofillHints: widget.enablePinAutofill && widget.enabled
-              ? <String>[AutofillHints.oneTimeCode]
-              : null,
-          autofocus: widget.autoFocus,
-          autocorrect: false,
-          keyboardType: widget.keyboardType,
-          textCapitalization: widget.textCapitalization,
-          validator: widget.validator,
-          onSaved: widget.onSaved,
-          autovalidateMode: widget.autovalidateMode,
-          inputFormatters: [
-            ...widget.inputFormatters,
-            LengthLimitingTextInputFormatter(widget.length),
+          alignment: .bottomCenter,
+          children: <Widget>[
+            _HiddenTextFormField(
+              controller: textEditingController!,
+              focusNode: focusNode!,
+              enabled: widget.enabled,
+              enablePinAutofill: widget.enablePinAutofill,
+              autoFocus: widget.autoFocus,
+              keyboardType: widget.keyboardType,
+              textCapitalization: widget.textCapitalization,
+              validator: widget.validator,
+              onSaved: widget.onSaved,
+              autovalidateMode: widget.autovalidateMode,
+              inputFormatters: widget.inputFormatters,
+              length: widget.length,
+              onSubmitted: widget.onSubmitted,
+              onEditingComplete: widget.onEditingComplete,
+              scrollPadding: widget.scrollPadding,
+              readOnly: widget.readOnly,
+              onAutoFillDisposeAction: widget.onAutoFillDisposeAction,
+              inputDecoration: widget.inputDecoration,
+            ),
+            _PinFieldsRow(
+              onTap: () {
+                widget.onTap?.call();
+                _onFocus();
+              },
+              onLongPress: widget.enabled
+                  ? () async {
+                      var data = await Clipboard.getData("text/plain");
+                      if (data != null && data.text != null) {
+                        if (widget.beforeTextPaste?.call(data.text) ?? true) {
+                          textEditingController!.text = data.text!;
+                        }
+                      }
+                    }
+                  : null,
+              mainAxisAlignment: widget.mainAxisAlignment,
+              length: widget.length,
+              pinTheme: pinTheme,
+              animationCurve: widget.animationCurve,
+              animationDuration: widget.animationDuration,
+              enableActiveFill: widget.enableActiveFill,
+              boxShadows: widget.boxShadows,
+              borderRadius: borderRadius,
+              inputList: inputList,
+              hasFocus: focusNode!.hasFocus,
+              selectedIndex: selectedIndex,
+              obscureText: widget.obscureText,
+              obscuringWidget: widget.obscuringWidget,
+              obscuringCharacter: widget.obscuringCharacter,
+              textStyle: widget.textStyle,
+              hintCharacter: widget.hintCharacter,
+              hintStyle: widget.hintStyle,
+              showCursor: widget.showCursor,
+              cursorColor: widget.cursorColor,
+              cursorHeight: widget.cursorHeight,
+              cursorWidth: widget.cursorWidth,
+              cursorAnimation: cursorAnimation,
+              separatorBuilder: widget.separatorBuilder,
+              isInErrorMode: isInErrorMode,
+              enabled: widget.enabled,
+            ),
           ],
-          onFieldSubmitted: widget.onSubmitted,
-          onEditingComplete: widget.onEditingComplete,
-          showCursor: false,
-          cursorWidth: 0.01,
-          decoration: const InputDecoration(
-            contentPadding: EdgeInsets.all(0),
-            border: InputBorder.none,
-            enabledBorder: InputBorder.none,
-            focusedBorder: InputBorder.none,
-            disabledBorder: InputBorder.none,
-          ),
-          style: TextStyle(
-            color: Colors.transparent,
-            height: 0.01,
-            fontSize: kIsWeb ? 1 : 0.01,
-          ),
-          scrollPadding: widget.scrollPadding,
-          readOnly: widget.readOnly,
         ),
       ),
     );
   }
+}
 
-  /// Builds the visible PIN fields that the user interacts with.
-  Widget _buildPinFields() {
+/// A hidden [TextFormField] that handles the actual text input.
+///
+/// This widget is invisible to the user but captures keyboard input
+/// and manages autofill functionality for OTP codes.
+class _HiddenTextFormField extends StatelessWidget {
+  const _HiddenTextFormField({
+    required this.controller,
+    required this.focusNode,
+    required this.enabled,
+    required this.enablePinAutofill,
+    required this.autoFocus,
+    required this.keyboardType,
+    required this.textCapitalization,
+    required this.autovalidateMode,
+    required this.inputFormatters,
+    required this.length,
+    required this.scrollPadding,
+    required this.readOnly,
+    required this.onAutoFillDisposeAction,
+    this.validator,
+    this.onSaved,
+    this.onSubmitted,
+    this.onEditingComplete,
+    this.inputDecoration,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final bool enabled;
+  final bool enablePinAutofill;
+  final bool autoFocus;
+  final TextInputType keyboardType;
+  final TextCapitalization textCapitalization;
+  final FormFieldValidator<String>? validator;
+  final FormFieldSetter<String>? onSaved;
+  final AutovalidateMode autovalidateMode;
+  final List<TextInputFormatter> inputFormatters;
+  final int length;
+  final ValueChanged<String>? onSubmitted;
+  final VoidCallback? onEditingComplete;
+  final EdgeInsets scrollPadding;
+  final bool readOnly;
+  final AutofillContextAction onAutoFillDisposeAction;
+  final InputDecoration? inputDecoration;
+
+  @override
+  Widget build(BuildContext context) => AbsorbPointer(
+    absorbing: true,
+    child: AutofillGroup(
+      onDisposeAction: onAutoFillDisposeAction,
+      child: TextFormField(
+        controller: controller,
+        focusNode: focusNode,
+        enabled: enabled,
+        autofillHints: enablePinAutofill && enabled
+            ? <String>[AutofillHints.oneTimeCode]
+            : null,
+        autofocus: autoFocus,
+        autocorrect: false,
+        keyboardType: keyboardType,
+        textCapitalization: textCapitalization,
+        validator: validator,
+        onSaved: onSaved,
+        autovalidateMode: autovalidateMode,
+        inputFormatters: [
+          ...inputFormatters,
+          LengthLimitingTextInputFormatter(length),
+        ],
+        onFieldSubmitted: onSubmitted,
+        onEditingComplete: onEditingComplete,
+        showCursor: false,
+        cursorWidth: 0.01,
+        decoration: inputDecoration ?? const InputDecoration(
+          contentPadding: EdgeInsets.all(0),
+          border: InputBorder.none,
+          enabledBorder: InputBorder.none,
+          focusedBorder: InputBorder.none,
+          disabledBorder: InputBorder.none,
+          fillColor: Colors.transparent,
+          focusColor: Colors.transparent,
+          hoverColor: Colors.transparent,
+          errorBorder: InputBorder.none,
+          focusedErrorBorder: InputBorder.none,
+        ),
+        style: TextStyle(color: Colors.transparent, height: 0.01, fontSize: kIsWeb ? 1 : 0.01),
+        scrollPadding: scrollPadding,
+        readOnly: readOnly,
+      ),
+    ),
+  );
+}
+
+/// Builds the visible row of PIN fields that the user interacts with.
+///
+/// Uses [PinFieldStyleCalculator] to compute styles for each field
+/// and generates widgets via `.expand()` for clean functional composition.
+class _PinFieldsRow extends StatelessWidget {
+  const _PinFieldsRow({
+    required this.onTap,
+    required this.mainAxisAlignment,
+    required this.length,
+    required this.pinTheme,
+    required this.animationCurve,
+    required this.animationDuration,
+    required this.enableActiveFill,
+    required this.inputList,
+    required this.hasFocus,
+    required this.selectedIndex,
+    required this.obscureText,
+    required this.obscuringCharacter,
+    required this.showCursor,
+    required this.cursorWidth,
+    required this.cursorAnimation,
+    required this.isInErrorMode,
+    required this.enabled,
+    this.onLongPress,
+    this.boxShadows,
+    this.borderRadius,
+    this.obscuringWidget,
+    this.textStyle,
+    this.hintCharacter,
+    this.hintStyle,
+    this.cursorColor,
+    this.cursorHeight,
+    this.separatorBuilder,
+  });
+
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final MainAxisAlignment mainAxisAlignment;
+  final int length;
+  final PinCodeTheme pinTheme;
+  final Curve animationCurve;
+  final Duration animationDuration;
+  final bool enableActiveFill;
+  final List<BoxShadow>? boxShadows;
+  final BorderRadius? borderRadius;
+  final List<String> inputList;
+  final bool hasFocus;
+  final int selectedIndex;
+  final bool obscureText;
+  final Widget? obscuringWidget;
+  final String obscuringCharacter;
+  final TextStyle? textStyle;
+  final String? hintCharacter;
+  final TextStyle? hintStyle;
+  final bool showCursor;
+  final Color? cursorColor;
+  final double? cursorHeight;
+  final double cursorWidth;
+  final Animation<double> cursorAnimation;
+  final IndexedWidgetBuilder? separatorBuilder;
+  final bool isInErrorMode;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final styleCalculator = PinFieldStyleCalculator(
+      pinTheme: pinTheme,
+      enabled: enabled,
+      hasFocus: hasFocus,
+      selectedIndex: selectedIndex,
+      isInErrorMode: isInErrorMode,
+      enableActiveFill: enableActiveFill,
+    );
+
     return Positioned(
       top: 0,
       left: 0,
       right: 0,
       child: GestureDetector(
-        onTap: () {
-          widget.onTap?.call();
-          _onFocus();
-        },
-        onLongPress: widget.enabled
-            ? () async {
-                var data = await Clipboard.getData("text/plain");
-                if (data != null && data.text != null) {
-                  if (widget.beforeTextPaste?.call(data.text) ?? true) {
-                    textEditingController!.text = data.text!;
-                  }
-                }
-              }
-            : null,
+        onTap: onTap,
+        onLongPress: onLongPress,
         child: Row(
-          mainAxisAlignment: widget.mainAxisAlignment,
-          children: _generateFields(),
+          mainAxisAlignment: mainAxisAlignment,
+          children: [
+            ...styleCalculator.calculate(length, inputList).expand((data) => [
+              _PinField(
+                data: data,
+                pinTheme: pinTheme,
+                animationCurve: animationCurve,
+                animationDuration: animationDuration,
+                boxShadows: boxShadows,
+                borderRadius: borderRadius,
+                hasFocus: hasFocus,
+                selectedIndex: selectedIndex,
+                length: length,
+                obscureText: obscureText,
+                obscuringWidget: obscuringWidget,
+                obscuringCharacter: obscuringCharacter,
+                textStyle: textStyle,
+                hintCharacter: hintCharacter,
+                hintStyle: hintStyle,
+                showCursor: showCursor,
+                cursorColor: cursorColor,
+                cursorHeight: cursorHeight,
+                cursorWidth: cursorWidth,
+                cursorAnimation: cursorAnimation,
+              ),
+              if (separatorBuilder != null && data.index < length - 1)
+                separatorBuilder!(context, data.index),
+            ]),
+          ],
         ),
       ),
     );
   }
+}
 
-  /// Generates the list of widgets for each individual PIN field.
-  List<Widget> _generateFields() {
-    var result = <Widget>[];
-    for (int i = 0; i < widget.length; i++) {
-      result.add(
-        AnimatedContainer(
-          padding: pinTheme.fieldOuterPadding,
-          curve: widget.animationCurve,
-          duration: widget.animationDuration,
-          width: pinTheme.fieldWidth,
-          height: pinTheme.fieldHeight,
-          decoration: BoxDecoration(
-            color: widget.enableActiveFill
-                ? _getFillColor(i)
-                : Colors.transparent,
-            boxShadow: widget.boxShadows,
-            shape: pinTheme.shape == PinCodeFieldShape.circle
-                ? BoxShape.circle
-                : BoxShape.rectangle,
-            borderRadius: borderRadius,
-            border: _getBorder(i),
-          ),
-          child: Center(
-            child: AnimatedSwitcher(
-              duration: widget.animationDuration,
-              transitionBuilder: (child, animation) =>
-                  FadeTransition(opacity: animation, child: child),
-              child: _buildChild(i),
+/// Renders a single PIN field with animated container and decoration.
+///
+/// Receives pre-calculated styles from [PinFieldData] to display
+/// the appropriate fill color and border based on the field state.
+class _PinField extends StatelessWidget {
+  const _PinField({
+    required this.data,
+    required this.pinTheme,
+    required this.animationCurve,
+    required this.animationDuration,
+    required this.hasFocus,
+    required this.selectedIndex,
+    required this.length,
+    required this.obscureText,
+    required this.obscuringCharacter,
+    required this.showCursor,
+    required this.cursorWidth,
+    required this.cursorAnimation,
+    this.boxShadows,
+    this.borderRadius,
+    this.obscuringWidget,
+    this.textStyle,
+    this.hintCharacter,
+    this.hintStyle,
+    this.cursorColor,
+    this.cursorHeight,
+  });
+
+  final PinFieldData data;
+  final PinCodeTheme pinTheme;
+  final Curve animationCurve;
+  final Duration animationDuration;
+  final List<BoxShadow>? boxShadows;
+  final BorderRadius? borderRadius;
+  final bool hasFocus;
+  final int selectedIndex;
+  final int length;
+  final bool obscureText;
+  final Widget? obscuringWidget;
+  final String obscuringCharacter;
+  final TextStyle? textStyle;
+  final String? hintCharacter;
+  final TextStyle? hintStyle;
+  final bool showCursor;
+  final Color? cursorColor;
+  final double? cursorHeight;
+  final double cursorWidth;
+  final Animation<double> cursorAnimation;
+
+  @override
+  Widget build(BuildContext context) => AnimatedContainer(
+    padding: pinTheme.fieldOuterPadding,
+    curve: animationCurve,
+    duration: animationDuration,
+    width: pinTheme.fieldWidth,
+    height: pinTheme.fieldHeight,
+    decoration: BoxDecoration(
+      color: data.fillColor,
+      boxShadow: boxShadows,
+      shape: pinTheme.shape == PinCodeFieldShape.circle ? BoxShape.circle : BoxShape.rectangle,
+      borderRadius: borderRadius,
+      border: data.border,
+    ),
+    child: Center(
+      child: AnimatedSwitcher(
+        duration: animationDuration,
+        transitionBuilder: (child, animation) =>
+            FadeTransition(opacity: animation, child: child),
+        child: _PinFieldChild(
+          index: data.index,
+          character: data.character,
+          hasFocus: hasFocus,
+          selectedIndex: selectedIndex,
+          length: length,
+          obscureText: obscureText,
+          obscuringWidget: obscuringWidget,
+          obscuringCharacter: obscuringCharacter,
+          textStyle: textStyle,
+          hintCharacter: hintCharacter,
+          hintStyle: hintStyle,
+          showCursor: showCursor,
+          cursorColor: cursorColor,
+          cursorHeight: cursorHeight,
+          cursorWidth: cursorWidth,
+          cursorAnimation: cursorAnimation,
+        ),
+      ),
+    ),
+  );
+}
+
+/// Renders the inner content of a PIN field (character, hint, or cursor).
+///
+/// Uses pattern matching to determine what to display based on:
+/// - Whether the field has a character entered
+/// - Whether the text should be obscured
+/// - Whether a hint character should be shown
+class _PinFieldChild extends StatelessWidget {
+  const _PinFieldChild({
+    required this.index,
+    required this.character,
+    required this.hasFocus,
+    required this.selectedIndex,
+    required this.length,
+    required this.obscureText,
+    required this.obscuringCharacter,
+    required this.showCursor,
+    required this.cursorWidth,
+    required this.cursorAnimation,
+    this.obscuringWidget,
+    this.textStyle,
+    this.hintCharacter,
+    this.hintStyle,
+    this.cursorColor,
+    this.cursorHeight,
+  });
+
+  final int index;
+  final String character;
+  final bool hasFocus;
+  final int selectedIndex;
+  final int length;
+  final bool obscureText;
+  final Widget? obscuringWidget;
+  final String obscuringCharacter;
+  final TextStyle? textStyle;
+  final String? hintCharacter;
+  final TextStyle? hintStyle;
+  final bool showCursor;
+  final Color? cursorColor;
+  final double? cursorHeight;
+  final double cursorWidth;
+  final Animation<double> cursorAnimation;
+
+  @override
+  Widget build(BuildContext context) => Stack(
+    alignment: .center,
+    children: [
+      switch ((character.isNotEmpty, obscureText, hintCharacter)) {
+        (true, true, _) => obscuringWidget ?? Text(obscuringCharacter, key: ValueKey('obscure_$index'), style: textStyle),
+        (true, false, _) => Text(character, key: ValueKey('char_$index'), style: textStyle),
+        (false, _, String hint) => Text(hint, key: ValueKey('hint_$index'), style: hintStyle),
+        _ => SizedBox.shrink(key: ValueKey('empty_$index')),
+      },
+      if (showCursor &&
+          hasFocus &&
+          (selectedIndex == index || (selectedIndex == index + 1 && index + 1 == length)))
+        FadeTransition(
+          opacity: cursorAnimation,
+          child: CustomPaint(
+            size: Size(0, cursorHeight ?? (textStyle?.fontSize ?? 20) + 8),
+            painter: PinCodePainter(
+              cursorColor: cursorColor ?? Theme.of(context).colorScheme.secondary,
+              cursorWidth: cursorWidth,
             ),
           ),
         ),
-      );
-      if (widget.separatorBuilder != null && i < widget.length - 1) {
-        result.add(widget.separatorBuilder!(context, i));
-      }
-    }
-    return result;
-  }
-
-  /// Builds the content of an individual PIN field (digit, cursor, hint, etc.).
-  // En PinCodeMixin
-
-  /// Construye el contenido de un campo de PIN individual (dígito, cursor, pista, etc.).
-  Widget _buildChild(int index) {
-    bool hasFocus = focusNode!.hasFocus;
-
-    // Determina qué se va a mostrar: el dígito, el hint o el widget de ocultación.
-    Widget characterChild;
-    if (inputList[index].isNotEmpty) {
-      if (widget.obscureText) {
-        characterChild =
-            widget.obscuringWidget ??
-            Text(
-              widget.obscuringCharacter,
-              key: ValueKey('obscure_$index'),
-              style: widget.textStyle,
-            );
-      } else {
-        characterChild = Text(
-          inputList[index],
-          key: ValueKey('char_$index'),
-          style: widget.textStyle,
-        );
-      }
-    } else if (widget.hintCharacter != null) {
-      characterChild = Text(
-        widget.hintCharacter!,
-        key: ValueKey('hint_$index'),
-        style: widget.hintStyle,
-      );
-    } else {
-      // Campo vacío sin hint
-      characterChild = SizedBox.shrink(key: ValueKey('empty_$index'));
-    }
-
-    // Determina si el cursor debe ser visible en este campo.
-    bool isCursorVisible =
-        widget.showCursor &&
-        hasFocus &&
-        (selectedIndex == index ||
-            (selectedIndex == index + 1 && index + 1 == widget.length));
-
-    if (isCursorVisible) {
-      final cursorColor =
-          widget.cursorColor ?? Theme.of(context).colorScheme.secondary;
-      final cursorHeight =
-          widget.cursorHeight ?? (widget.textStyle?.fontSize ?? 20) + 8;
-
-      // *** LA CORRECCIÓN CLAVE ***
-      // Usamos un Stack para dibujar el cursor ENCIMA del dígito.
-      return Stack(
-        alignment: Alignment.center,
-        children: [
-          characterChild, // El dígito o hint va en el fondo
-          FadeTransition(
-            opacity: cursorAnimation,
-            child: CustomPaint(
-              size: Size(0, cursorHeight),
-              painter: PinCodePainter(
-                cursorColor: cursorColor,
-                cursorWidth: widget.cursorWidth,
-              ),
-            ),
-          ),
-        ],
-      );
-    }
-
-    return characterChild;
-  }
-
-  // Helper methods to get dynamic styles
-
-  Color _getFillColor(int index) {
-    if (!widget.enabled) return pinTheme.disabledColor;
-    if (focusNode!.hasFocus && selectedIndex == index) {
-      return pinTheme.selectedFillColor;
-    }
-    if (selectedIndex > index) return pinTheme.activeFillColor;
-    return pinTheme.inactiveFillColor;
-  }
-
-  Border? _getBorder(int index) {
-    final color = _getBorderColor(index);
-    final width = _getBorderWidth(index);
-
-    if (pinTheme.shape == PinCodeFieldShape.underline) {
-      return Border(
-        bottom: BorderSide(color: color, width: width),
-      );
-    }
-    return Border.all(color: color, width: width);
-  }
-
-  Color _getBorderColor(int index) {
-    if (isInErrorMode) return pinTheme.errorBorderColor;
-    if (!widget.enabled) return pinTheme.disabledColor;
-    if (focusNode!.hasFocus && selectedIndex == index) {
-      return pinTheme.selectedColor;
-    }
-    if (selectedIndex > index) return pinTheme.activeColor;
-    return pinTheme.inactiveColor;
-  }
-
-  double _getBorderWidth(int index) {
-    if (isInErrorMode) return pinTheme.errorBorderWidth;
-    if (!widget.enabled) return pinTheme.disabledBorderWidth;
-    if (focusNode!.hasFocus && selectedIndex == index) {
-      return pinTheme.selectedBorderWidth;
-    }
-    if (selectedIndex > index) return pinTheme.activeBorderWidth;
-    return pinTheme.inactiveBorderWidth;
-  }
+    ],
+  );
 }
+
 //endregion

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -88,12 +88,12 @@ mixin PinCodeMixin on State<PinCode> {
     });
 
     errorAnimationSubscription = widget.errorAnimationController?.stream.listen((error) {
-      if (error == .shake) {
+      final bool isShake = error == .shake;
+
+      if (isShake) {
         errorController.forward();
-        setState(() => isInErrorMode = true);
-      } else if (error == .clear) {
-        setState(() => isInErrorMode = false);
       }
+      setState(() => isInErrorMode = isShake);
     });
   }
 

--- a/lib/src/pin_code_painters.dart
+++ b/lib/src/pin_code_painters.dart
@@ -11,13 +11,12 @@ class PinCodePainter extends CustomPainter {
   final double cursorWidth;
 
   PinCodePainter({this.cursorColor = Colors.black, this.cursorWidth = 2});
-
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = cursorColor
       ..strokeWidth = cursorWidth;
-    canvas.drawLine(Offset.zero, Offset(0, size.height), paint);
+    canvas.drawLine(.zero, Offset(0, size.height), paint);
   }
 
   @override

--- a/lib/src/pin_code_widget.dart
+++ b/lib/src/pin_code_widget.dart
@@ -160,6 +160,8 @@ class PinCode extends StatefulWidget {
   /// An optional builder to create separator widgets between each field.
   final IndexedWidgetBuilder? separatorBuilder;
 
+  final InputDecoration? inputDecoration;
+
   /// {@macro pin_code_text_field}
   const PinCode({
     super.key,
@@ -172,10 +174,10 @@ class PinCode extends StatefulWidget {
     this.onChanged,
     this.onCompleted,
     this.backgroundColor,
-    this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
+    this.mainAxisAlignment = .spaceBetween,
     this.animationDuration = const Duration(milliseconds: 150),
     this.animationCurve = Curves.easeInOut,
-    this.keyboardType = TextInputType.number,
+    this.keyboardType = .number,
     this.autoFocus = false,
     this.focusNode,
     this.onTap,
@@ -184,8 +186,8 @@ class PinCode extends StatefulWidget {
     this.textStyle,
     this.useHapticFeedback = false,
     this.enableActiveFill = false,
-    this.textCapitalization = TextCapitalization.none,
-    this.textInputAction = TextInputAction.done,
+    this.textCapitalization = .none,
+    this.textInputAction = .done,
     this.autoDismissKeyboard = true,
     this.autoDisposeControllers = true,
     this.onSubmitted,
@@ -195,7 +197,7 @@ class PinCode extends StatefulWidget {
     this.pinTheme = const PinCodeTheme(),
     this.validator,
     this.onSaved,
-    this.autovalidateMode = AutovalidateMode.onUserInteraction,
+    this.autovalidateMode = .onUserInteraction,
     this.errorTextSpace = 16,
     this.enablePinAutofill = true,
     this.errorAnimationDuration = 500,
@@ -208,9 +210,10 @@ class PinCode extends StatefulWidget {
     this.hintStyle,
     this.readOnly = false,
     this.autoUnfocus = true,
-    this.onAutoFillDisposeAction = AutofillContextAction.commit,
+    this.onAutoFillDisposeAction = .commit,
     this.scrollPadding = const EdgeInsets.all(20),
     this.separatorBuilder,
+    this.inputDecoration
   });
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/JhonaCodes/pin_code
 
 environment:
   sdk: ^3.10.0
-  flutter: ">=3.38.5"
+  flutter: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.0
 homepage: https://github.com/JhonaCodes/pin_code
 
 environment:
-  sdk: ^3.10.1
+  sdk: ^3.10.0
   flutter: ">=3.38.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: pin_code
 description: A flexible and fully customizable widget for PIN, OTP, and passcode entry. Perfect for verification screens, 2FA, transaction confirmations, and more.
-version: 1.0.2
+version: 1.2.0
 homepage: https://github.com/JhonaCodes/pin_code
 
 environment:
-  sdk: ^3.8.1
-  flutter: ">=1.17.0"
+  sdk: ^3.10.1
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/JhonaCodes/pin_code
 
 environment:
   sdk: ^3.10.0
-  flutter: ">=3.38.0"
+  flutter: ">=3.38.5"
 
 dependencies:
   flutter:

--- a/test/scenarios_test.dart
+++ b/test/scenarios_test.dart
@@ -10,7 +10,7 @@ void main() {
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24.0),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisAlignment: .center,
             children: [
               const Icon(Icons.lock, color: Colors.white, size: 48),
               const SizedBox(height: 24),
@@ -26,7 +26,7 @@ void main() {
                   showCursor: false,
                   controller: TextEditingController(text: "12"),
                   pinTheme: PinCodeTheme(
-                    shape: PinCodeFieldShape.box,
+                    shape: .box,
                     fieldHeight: 60,
                     fieldWidth: 60,
                     borderRadius: BorderRadius.circular(12),
@@ -69,18 +69,18 @@ void main() {
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 32.0),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisAlignment: .center,
+            crossAxisAlignment: .stretch,
             children: [
               const Text(
                 'Verify Your Account',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                textAlign: .center,
+                style: TextStyle(fontSize: 24, fontWeight: .bold),
               ),
               const SizedBox(height: 16),
               Text(
                 'We sent a 6-digit code to your@email.com',
-                textAlign: TextAlign.center,
+                textAlign: .center,
                 style: TextStyle(fontSize: 16, color: Colors.grey.shade600),
               ),
               const SizedBox(height: 40),
@@ -92,7 +92,7 @@ void main() {
                   controller: TextEditingController(text: "123"),
                   enableActiveFill: true,
                   pinTheme: PinCodeTheme(
-                    shape: PinCodeFieldShape.box,
+                    shape: .box,
                     borderRadius: BorderRadius.circular(8),
                     activeColor: Colors.black,
                     inactiveColor: Colors.grey.shade300,
@@ -132,7 +132,7 @@ void main() {
           body: Container(
             padding: const EdgeInsets.all(30),
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisAlignment: .center,
               children: [
                 const CircleAvatar(
                   backgroundColor: Colors.green,
@@ -142,12 +142,12 @@ void main() {
                 const SizedBox(height: 20),
                 const Text(
                   'Enter Confirmation Code',
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: 20, fontWeight: .bold),
                 ),
                 const SizedBox(height: 10),
                 const Text(
                   'Check your banking app for the 5-character code.',
-                  textAlign: TextAlign.center,
+                  textAlign: .center,
                   style: TextStyle(color: Colors.black54),
                 ),
                 const SizedBox(height: 30),
@@ -155,11 +155,11 @@ void main() {
                   builder: (context) => PinCode(
                     appContext: context,
                     length: 5,
-                    keyboardType: TextInputType.text, // Alfanumérico
+                    keyboardType: .text, // Alfanumérico
                     controller: TextEditingController(text: "A4B"),
                     showCursor: false,
                     pinTheme: PinCodeTheme(
-                      shape: PinCodeFieldShape.underline,
+                      shape: .underline,
                       fieldHeight: 50,
                       fieldWidth: 40,
                       activeColor: Colors.black,
@@ -168,7 +168,7 @@ void main() {
                     ),
                     textStyle: const TextStyle(
                       fontSize: 22,
-                      fontWeight: FontWeight.w500,
+                      fontWeight: .w500,
                     ),
                   ),
                 ),

--- a/test/theme_and_layout_test.dart
+++ b/test/theme_and_layout_test.dart
@@ -30,7 +30,7 @@ void main() {
             controller: TextEditingController(text: "123"),
             showCursor: false,
             pinTheme: PinCodeTheme(
-              shape: PinCodeFieldShape.box,
+              shape: .box,
               borderRadius: BorderRadius.circular(5),
             ),
           ),
@@ -48,7 +48,7 @@ void main() {
             length: 4,
             controller: TextEditingController(text: "123"),
             showCursor: false,
-            pinTheme: PinCodeTheme(shape: PinCodeFieldShape.circle),
+            pinTheme: PinCodeTheme(shape: .circle),
           ),
         ),
       );
@@ -66,7 +66,7 @@ void main() {
             controller: TextEditingController(text: "123"),
             showCursor: false,
             pinTheme: PinCodeTheme(
-              shape: PinCodeFieldShape.box,
+              shape: .box,
               borderRadius: BorderRadius.circular(8),
               activeColor: Colors.blue.shade800,
               inactiveColor: Colors.grey.shade400,
@@ -109,11 +109,11 @@ void main() {
           builder: (context) => PinCode(
             appContext: context,
             length: 4,
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            mainAxisAlignment: .spaceEvenly,
             controller: TextEditingController(text: "98"),
             showCursor: false,
             pinTheme: PinCodeTheme(
-              shape: PinCodeFieldShape.box,
+              shape: .box,
               borderRadius: BorderRadius.circular(20),
               fieldHeight: 70,
               fieldWidth: 60,


### PR DESCRIPTION
Fixed:
- InputDecorationTheme no longer overrides hidden TextFormField styles
- Added explicit transparent decorations to prevent theme inheritance

Added:
- inputDecoration parameter for custom hidden input styling

Changed:
- PinFieldStyleCalculator: separates style logic from UI
- PinFieldData: Dart 3 record for pre-calculated styles
- Private widgets: _HiddenTextFormField, _PinFieldsRow, _PinField
- Functional composition with .expand() pattern

Thanks to @Pavluke for reporting the theme issue [(PR #2)](https://github.com/JhonaCodes/pin_code/pull/2)